### PR TITLE
Update RELEASE_NOTES.md for 0.1.1 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 0.1.1 November 14 2023 ####
+
+* [AspNet.OpenTracing: Fix "Server cannot append header after HTTP headers have been sent" bug](https://github.com/petabridge/Petabridge.OpenTracing.Contrib/pull/6)
+
 #### 0.1.0 October 17 2023 ####
 
 Initial release of Petabridge.AspNet.OpenTracing, an OpenTracing HttpModule compatible with .NET FX 4.6.1 and ASP.NET


### PR DESCRIPTION
## 0.1.1 November 14 2023

* [AspNet.OpenTracing: Fix "Server cannot append header after HTTP headers have been sent" bug](https://github.com/petabridge/Petabridge.OpenTracing.Contrib/pull/6)